### PR TITLE
Make ports, export paths configurable

### DIFF
--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -48,7 +48,7 @@ const (
 // Global variables for the controller
 var PVLock sync.Map
 
-const DEFAULT_NFS_SERVER_PORT string = "2049"
+const DefaultNFSServerPort string = "2049"
 
 func (cs *CsiNfsService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	// Don't do anything in CreateVolume expect change the volume ID and parameters to avoid recursion
@@ -250,7 +250,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 	port, err := strconv.Atoi(cs.nfsServerPort)
 	if err != nil {
 		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
-		port, _ = strconv.Atoi(DEFAULT_NFS_SERVER_PORT) // default to 2049 if invalid port is parsed
+		port, _ = strconv.Atoi(DefaultNFSServerPort) // default to 2049 if invalid port is parsed
 	}
 	var portNumber int32 = int32(port) // #nosec : G109,G115
 

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -250,7 +250,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
 		port = 2049 // default to 2049 if invalid port is parsed
 	}
-	var portNumber int32 = int32(port)
+	var portNumber int32 = int32(port) // nosec : G109
 	endpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -48,6 +48,8 @@ const (
 // Global variables for the controller
 var PVLock sync.Map
 
+const DEFAULT_NFS_SERVER_PORT string = "2049"
+
 func (cs *CsiNfsService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	// Don't do anything in CreateVolume expect change the volume ID and parameters to avoid recursion
 	delete(req.Parameters, CsiNfsParameter)
@@ -245,12 +247,13 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 
 	// Create the endpointslice
 	portName := "nfs-server"
-	port, err := strconv.Atoi(os.Getenv(EnvNFSServerPort))
+	port, err := strconv.Atoi(cs.nfsServerPort)
 	if err != nil {
 		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
-		port = 2049 // default to 2049 if invalid port is parsed
+		port, _ = strconv.Atoi(DEFAULT_NFS_SERVER_PORT) // default to 2049 if invalid port is parsed
 	}
 	var portNumber int32 = int32(port) // #nosec : G109,G115
+
 	endpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -385,7 +388,7 @@ func (cs *CsiNfsService) callExportNfsVolume(ctx context.Context, nodeIPAddress 
 	defer finish(ctx, "callExportNfsVolume", requestID, start)
 	// Call the node driver to do the NFS export.
 	log.Infof("Working on calling nfsExportVolume")
-	nodeClient, err := getNfsClient(nodeIPAddress, getServerPort())
+	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsServerPort)
 	if err != nil {
 		log.Errorf("Couldn't getNfsClient: %s", err.Error())
 		deleteNfsClient(nodeIPAddress)
@@ -402,7 +405,7 @@ func (cs *CsiNfsService) callUnexportNfsVolume(ctx context.Context, nodeIPAddres
 	defer finish(ctx, "callUnexportNfsVolume", requestID, start)
 	// Call the node driver to do the NFS unexport.
 	log.Infof("Working on calling nfsUnexportVolume")
-	nodeClient, err := getNfsClient(nodeIPAddress, getServerPort())
+	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsServerPort)
 	if err != nil {
 		log.Errorf("Couldn't getNfsClient: %s", err.Error())
 		deleteNfsClient(nodeIPAddress)

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -249,9 +249,10 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 	portName := "nfs-server"
 	port, err := strconv.Atoi(cs.nfsServerPort)
 	if err != nil {
-		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
+		log.Warnf("invalid port %s - err %v. Defaulting to 2049", os.Getenv(EnvNFSServerPort), err)
 		port, _ = strconv.Atoi(DefaultNFSServerPort) // default to 2049 if invalid port is parsed
 	}
+	log.Infof("Setting NFS server port to %d", port)
 	var portNumber int32 = int32(port) // #nosec : G109,G115
 
 	endpointSlice := &discoveryv1.EndpointSlice{
@@ -388,7 +389,7 @@ func (cs *CsiNfsService) callExportNfsVolume(ctx context.Context, nodeIPAddress 
 	defer finish(ctx, "callExportNfsVolume", requestID, start)
 	// Call the node driver to do the NFS export.
 	log.Infof("Working on calling nfsExportVolume")
-	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsServerPort)
+	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsClientServicePort)
 	if err != nil {
 		log.Errorf("Couldn't getNfsClient: %s", err.Error())
 		deleteNfsClient(nodeIPAddress)
@@ -405,7 +406,7 @@ func (cs *CsiNfsService) callUnexportNfsVolume(ctx context.Context, nodeIPAddres
 	defer finish(ctx, "callUnexportNfsVolume", requestID, start)
 	// Call the node driver to do the NFS unexport.
 	log.Infof("Working on calling nfsUnexportVolume")
-	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsServerPort)
+	nodeClient, err := getNfsClient(nodeIPAddress, cs.nfsClientServicePort)
 	if err != nil {
 		log.Errorf("Couldn't getNfsClient: %s", err.Error())
 		deleteNfsClient(nodeIPAddress)

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -243,7 +245,12 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 
 	// Create the endpointslice
 	portName := "nfs-server"
-	var portNumber int32 = 2049
+	port, err := strconv.Atoi(os.Getenv(EnvNFSServerPort))
+	if err != nil {
+		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
+		port = 2049 // default to 2049 if invalid port is parsed
+	}
+	var portNumber int32 = int32(port)
 	endpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -307,7 +314,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 			Ports: []corev1.ServicePort{
 				{
 					Name:     "nfs-server",
-					Port:     2049,
+					Port:     portNumber,
 					Protocol: corev1.ProtocolTCP,
 				},
 			},

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -250,7 +250,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 		log.Warnf("invalid port %s - err %v", os.Getenv(EnvNFSServerPort), err)
 		port = 2049 // default to 2049 if invalid port is parsed
 	}
-	var portNumber int32 = int32(port) // nosec : G109
+	var portNumber int32 = int32(port) // #nosec : G109,G115
 	endpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -249,7 +248,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 	portName := "nfs-server"
 	port, err := strconv.Atoi(cs.nfsServerPort)
 	if err != nil {
-		log.Warnf("invalid port %s - err %v. Defaulting to 2049", os.Getenv(EnvNFSServerPort), err)
+		log.Warnf("invalid port %s - err %v. Defaulting to 2049", cs.nfsServerPort, err)
 		port, _ = strconv.Atoi(DefaultNFSServerPort) // default to 2049 if invalid port is parsed
 	}
 	log.Infof("Setting NFS server port to %d", port)

--- a/nfs/controller_test.go
+++ b/nfs/controller_test.go
@@ -294,7 +294,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 				return csiNfsServce
 			}(),
@@ -365,7 +365,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 				return csiNfsService
 			}(),
@@ -444,7 +444,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 
 				return csiNfsService
@@ -510,7 +510,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 				return csiNfsService
 			}(),
@@ -599,7 +599,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 				return csiNfsService
 			}(),
@@ -701,7 +701,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsServerPort:                port,
+					nfsClientServicePort:                port,
 				}
 				return csiNfsService
 			}(),
@@ -874,7 +874,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 			k8sclient: &k8s.Client{
 				Clientset: fakeK8sClient,
 			},
-			nfsServerPort: port,
+			nfsClientServicePort: port,
 		}
 
 		req := csi.ControllerUnpublishVolumeRequest{
@@ -918,7 +918,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 			k8sclient: &k8s.Client{
 				Clientset: fakeK8sClient,
 			},
-			nfsServerPort: port,
+			nfsClientServicePort: port,
 		}
 
 		req := csi.ControllerUnpublishVolumeRequest{

--- a/nfs/controller_test.go
+++ b/nfs/controller_test.go
@@ -294,7 +294,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 				return csiNfsServce
 			}(),
@@ -365,7 +365,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 				return csiNfsService
 			}(),
@@ -444,7 +444,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 
 				return csiNfsService
@@ -510,7 +510,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 				return csiNfsService
 			}(),
@@ -599,7 +599,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 				return csiNfsService
 			}(),
@@ -701,7 +701,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
-					nfsClientServicePort:                port,
+					nfsClientServicePort:         port,
 				}
 				return csiNfsService
 			}(),

--- a/nfs/controller_test.go
+++ b/nfs/controller_test.go
@@ -19,9 +19,12 @@ package nfs
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"log"
+	"math/big"
 	reflect "reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -222,6 +225,10 @@ func TestUnlockPV(t *testing.T) {
 }
 
 func TestControllerPublishVolume(t *testing.T) {
+	port := func() string {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(9000))
+		return strconv.Itoa(int(nBig.Int64() + 1000))
+	}()
 	tests := []struct {
 		name          string
 		csiNfsService *CsiNfsService
@@ -229,13 +236,14 @@ func TestControllerPublishVolume(t *testing.T) {
 		expectedRes   *csi.ControllerPublishVolumeResponse
 		expectedErr   error
 		createServer  func(*testing.T)
+		port          func()
 	}{
 		{
 			name: "Valid volume request",
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -286,6 +294,7 @@ func TestControllerPublishVolume(t *testing.T) {
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
 				return csiNfsServce
 			}(),
@@ -317,7 +326,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -350,14 +359,15 @@ func TestControllerPublishVolume(t *testing.T) {
 					}, nil
 				})
 
-				csiNfsServce := &CsiNfsService{
+				csiNfsService := &CsiNfsService{
 					vcsi: mockService,
 					k8sclient: &k8s.Client{
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
-				return csiNfsServce
+				return csiNfsService
 			}(),
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId: "test-volume",
@@ -387,7 +397,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -428,14 +438,16 @@ func TestControllerPublishVolume(t *testing.T) {
 					}, nil
 				})
 
-				csiNfsServce := &CsiNfsService{
+				csiNfsService := &CsiNfsService{
 					vcsi: mockService,
 					k8sclient: &k8s.Client{
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
-				return csiNfsServce
+
+				return csiNfsService
 			}(),
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId: "test-volume",
@@ -465,7 +477,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -492,14 +504,15 @@ func TestControllerPublishVolume(t *testing.T) {
 					return true, nil, nil
 				})
 
-				csiNfsServce := &CsiNfsService{
+				csiNfsService := &CsiNfsService{
 					vcsi: mockService,
 					k8sclient: &k8s.Client{
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
-				return csiNfsServce
+				return csiNfsService
 			}(),
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId: "test-volume",
@@ -524,7 +537,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -580,14 +593,15 @@ func TestControllerPublishVolume(t *testing.T) {
 					}, nil
 				})
 
-				csiNfsServce := &CsiNfsService{
+				csiNfsService := &CsiNfsService{
 					vcsi: mockService,
 					k8sclient: &k8s.Client{
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
-				return csiNfsServce
+				return csiNfsService
 			}(),
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId: "test-volume",
@@ -617,7 +631,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			createServer: func(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.ExportNfsVolumeResponse{}, nil)
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				nodeIPAddress["127.0.0.1"] = &NodeStatus{
 					online:     true,
 					inRecovery: false,
@@ -681,14 +695,15 @@ func TestControllerPublishVolume(t *testing.T) {
 					}, nil
 				})
 
-				csiNfsServce := &CsiNfsService{
+				csiNfsService := &CsiNfsService{
 					vcsi: mockService,
 					k8sclient: &k8s.Client{
 						Clientset: fakeK8sClient,
 					},
 					waitCreateNfsServiceInterval: 10 * time.Millisecond,
+					nfsServerPort:                port,
 				}
-				return csiNfsServce
+				return csiNfsService
 			}(),
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId: "test-volume",
@@ -739,6 +754,11 @@ func TestControllerPublishVolume(t *testing.T) {
 }
 
 func TestControllerUnpublishVolume(t *testing.T) {
+	port := func() string {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(9000))
+		return strconv.Itoa(int(nBig.Int64() + 1000))
+	}()
+
 	t.Run("endpoint error", func(t *testing.T) {
 		ctx := context.Background()
 		fakeK8sClient := fake.NewClientset()
@@ -848,12 +868,13 @@ func TestControllerUnpublishVolume(t *testing.T) {
 		mockVcsiService := mocks.NewMockService(gomock.NewController(t))
 		mockVcsiService.EXPECT().ControllerUnpublishVolume(gomock.Any(), gomock.Any()).Times(1).Return(&csi.ControllerUnpublishVolumeResponse{}, nil)
 
-		createMockServer(t, "127.0.0.1", mockNfsServer)
-		csiNfsServce := &CsiNfsService{
+		createMockServer(t, "127.0.0.1", port, mockNfsServer)
+		csiNfsService := &CsiNfsService{
 			vcsi: mockVcsiService,
 			k8sclient: &k8s.Client{
 				Clientset: fakeK8sClient,
 			},
+			nfsServerPort: port,
 		}
 
 		req := csi.ControllerUnpublishVolumeRequest{
@@ -861,7 +882,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 			NodeId:   "test-node",
 		}
 
-		_, err := csiNfsServce.ControllerUnpublishVolume(ctx, &req)
+		_, err := csiNfsService.ControllerUnpublishVolume(ctx, &req)
 		assert.Equal(t, nil, err)
 	})
 
@@ -889,7 +910,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 		}, metav1.CreateOptions{})
 		mockServer := mocks.NewMockNfsServer(gomock.NewController(t))
 		mockServer.EXPECT().UnexportNfsVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.UnexportNfsVolumeResponse{}, nil)
-		createMockServer(t, "127.0.0.1", mockServer)
+		createMockServer(t, "127.0.0.1", port, mockServer)
 		mockVcsiService := mocks.NewMockService(gomock.NewController(t))
 		mockVcsiService.EXPECT().ControllerUnpublishVolume(gomock.Any(), gomock.Any()).Times(0).Return(&csi.ControllerUnpublishVolumeResponse{}, nil)
 		csiNfsServce := &CsiNfsService{
@@ -897,6 +918,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 			k8sclient: &k8s.Client{
 				Clientset: fakeK8sClient,
 			},
+			nfsServerPort: port,
 		}
 
 		req := csi.ControllerUnpublishVolumeRequest{

--- a/nfs/csinfs.go
+++ b/nfs/csinfs.go
@@ -62,6 +62,7 @@ type CsiNfsService struct {
 	executor                     Executor
 	waitCreateNfsServiceInterval time.Duration
 	nfsServerPort                string
+	nfsClientServicePort         string
 }
 
 // OSInterface is an interface that is satisfied by various functions from the
@@ -267,6 +268,7 @@ func (s *CsiNfsService) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin,
 	log.Infof("NFS Driver Mode: %s Node Name %s", s.mode, s.nodeName)
 
 	s.nfsServerPort = os.Getenv(EnvNFSServerPort)
+	s.nfsClientServicePort = os.Getenv(EnvNFSClientServicePort)
 
 	// Validate the global variables that must be set up
 	if err := s.validateGlobalVariables(); err != nil {
@@ -322,7 +324,7 @@ func (s *CsiNfsService) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin,
 	// Start the NFS server listener
 	// TODO: make port configurable from environment
 	go func() {
-		err := startNfsServiceServer(s.nodeIPAddress, s.nfsServerPort, listen, serve)
+		err := startNfsServiceServer(s.nodeIPAddress, s.nfsClientServicePort, listen, serve)
 		if err != nil {
 			log.Errorf("failed to start nfs service. err: %s", err.Error())
 		}

--- a/nfs/csinfs.go
+++ b/nfs/csinfs.go
@@ -61,6 +61,7 @@ type CsiNfsService struct {
 	k8sclient                    *k8s.Client
 	executor                     Executor
 	waitCreateNfsServiceInterval time.Duration
+	nfsServerPort                string
 }
 
 // OSInterface is an interface that is satisfied by various functions from the
@@ -265,6 +266,8 @@ func (s *CsiNfsService) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin,
 	}
 	log.Infof("NFS Driver Mode: %s Node Name %s", s.mode, s.nodeName)
 
+	s.nfsServerPort = os.Getenv(EnvNFSServerPort)
+
 	// Validate the global variables that must be set up
 	if err := s.validateGlobalVariables(); err != nil {
 		return err
@@ -319,7 +322,7 @@ func (s *CsiNfsService) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin,
 	// Start the NFS server listener
 	// TODO: make port configurable from environment
 	go func() {
-		err := startNfsServiceServer(s.nodeIPAddress, getServerPort(), listen, serve)
+		err := startNfsServiceServer(s.nodeIPAddress, s.nfsServerPort, listen, serve)
 		if err != nil {
 			log.Errorf("failed to start nfs service. err: %s", err.Error())
 		}

--- a/nfs/csinfs_test.go
+++ b/nfs/csinfs_test.go
@@ -776,6 +776,8 @@ func TestCsiNfsService_BeforeServe(t *testing.T) {
 
 				// mocks for initializeNfsServer
 				executor := mocks.NewMockExecutor(gomock.NewController(t))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
+
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").
 					Times(1).Return([]byte("Active: active"), nil)
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").
@@ -842,6 +844,15 @@ func TestCsiNfsService_BeforeServe(t *testing.T) {
 
 				// mocks for initializeNfsServer
 				executor := mocks.NewMockExecutor(gomock.NewController(t))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").
+					Times(1).Return(nil, errors.New("mocked error"))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").
+					Times(1).Return(nil, errors.New("mocked error"))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").
+					Times(1).Return([]byte{}, nil)
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "start", "nfs-server").
+					Times(1).Return([]byte{}, nil)
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").
 					Times(1).Return([]byte("Active: active"), nil)
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").
@@ -908,11 +919,17 @@ func TestCsiNfsService_BeforeServe(t *testing.T) {
 
 				// mocks for initializeNfsServer
 				executor := mocks.NewMockExecutor(gomock.NewController(t))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
+				// executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").
+				// 	Times(1).Return([]byte{}, nil)
+				// executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-mountd").
+				// 	Times(1).Return([]byte{}, nil)
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").
 					Times(1).Return(nil, errors.New("mocked error"))
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").
 					Times(1).Return([]byte("Active: active"), nil)
-				executor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return(nil, errors.New("mock error"))
+				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").
+					Times(1).Return(nil, errors.New("mocked error"))
 				tc.fields.executor = executor
 			},
 			wantErr:    false,

--- a/nfs/csinfs_test.go
+++ b/nfs/csinfs_test.go
@@ -920,10 +920,6 @@ func TestCsiNfsService_BeforeServe(t *testing.T) {
 				// mocks for initializeNfsServer
 				executor := mocks.NewMockExecutor(gomock.NewController(t))
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
-				// executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").
-				// 	Times(1).Return([]byte{}, nil)
-				// executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-mountd").
-				// 	Times(1).Return([]byte{}, nil)
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").
 					Times(1).Return(nil, errors.New("mocked error"))
 				executor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").

--- a/nfs/env.go
+++ b/nfs/env.go
@@ -17,9 +17,9 @@ limitations under the License.
 package nfs
 
 const (
-	EnvPodCIDR       = "PodCIDR"
-	EnvNodeName      = "NODE_NAME"
-	EnvCSINodeName   = "X_CSI_NODE_NAME"
-	EnvNFSServerPort = "X_CSI_NFS_SERVER_PORT"
-	EnvNFSClientPort = "X_CSI_NFS_CLIENT_PORT"
+	EnvPodCIDR              = "PodCIDR"
+	EnvNodeName             = "NODE_NAME"
+	EnvCSINodeName          = "X_CSI_NODE_NAME"
+	EnvNFSServerPort        = "X_CSI_NFS_SERVER_PORT"
+	EnvNFSClientServicePort = "X_CSI_NFS_CLIENT_PORT"
 )

--- a/nfs/env.go
+++ b/nfs/env.go
@@ -17,7 +17,9 @@ limitations under the License.
 package nfs
 
 const (
-	EnvPodCIDR     = "PodCIDR"
-	EnvNodeName    = "NODE_NAME"
-	EnvCSINodeName = "X_CSI_NODE_NAME"
+	EnvPodCIDR       = "PodCIDR"
+	EnvNodeName      = "NODE_NAME"
+	EnvCSINodeName   = "X_CSI_NODE_NAME"
+	EnvNFSServerPort = "X_CSI_NFS_SERVER_PORT"
+	EnvNFSClientPort = "X_CSI_NFS_CLIENT_PORT"
 )

--- a/nfs/exports.go
+++ b/nfs/exports.go
@@ -216,7 +216,7 @@ func restartNFSMountd() error {
 	exportsLock.Lock()
 	defer exportsLock.Unlock()
 	log.Infof("restarting nfs-mountd")
-	output, err := GetLocalExecutor().ExecuteCommand("chroot", "/noderoot", "container-systemctl", "restart", "nfs-mountd")
+	output, err := GetLocalExecutor().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "restart", "nfs-mountd")
 	if err != nil {
 		return fmt.Errorf("failed to restart nfs-mountd: %v, output: %s", err, string(output))
 	}
@@ -242,7 +242,7 @@ func restartNFSMountd() error {
 
 // isNfsMountdActive checks if the nfs-mountd service is active
 func isNfsMountdActive() bool {
-	_, err := GetLocalExecutor().ExecuteCommand("chroot", "/noderoot", "container-systemctl", "is-active", "--quiet", "nfs-mountd")
+	_, err := GetLocalExecutor().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "is-active", "--quiet", "nfs-mountd")
 	return err == nil
 }
 

--- a/nfs/exports_test.go
+++ b/nfs/exports_test.go
@@ -570,7 +570,7 @@ func TestIsNfsMountdActive(t *testing.T) {
 			GetLocalExecutor = func() Executor {
 				return me
 			}
-			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "container-systemctl", "is-active", "--quiet", "nfs-mountd").Return(tt.mockReturn, tt.mockError)
+			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "is-active", "--quiet", "nfs-mountd").Return(tt.mockReturn, tt.mockError)
 
 			value := isNfsMountdActive()
 			assert.Equal(t, tt.expected, value)
@@ -822,8 +822,8 @@ func TestRestartNFSMountd(t *testing.T) {
 				return me
 			}
 			waitTime = tt.wait
-			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "container-systemctl", "restart", "nfs-mountd").Return(tt.mockReturn, tt.mockRestartNFSError)
-			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "container-systemctl", "is-active", "--quiet", "nfs-mountd").Return(tt.mockReturn, tt.mockIsNFSActiveError).AnyTimes()
+			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "restart", "nfs-mountd").Return(tt.mockReturn, tt.mockRestartNFSError)
+			me.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "is-active", "--quiet", "nfs-mountd").Return(tt.mockReturn, tt.mockIsNFSActiveError).AnyTimes()
 
 			GetLocalExecutor = func() Executor {
 				return me

--- a/nfs/init_nfs_server.go
+++ b/nfs/init_nfs_server.go
@@ -26,6 +26,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var knownHostsPath = "/noderoot/root/.ssh/known_hosts"
+
 // updateKnownHosts updates the known_hosts file with the keys from ssh-keyscan.
 // This is required to support systemctl commands or else host verification will fail
 // Updates known_hosts with the keys from ssh-keyscan, if necessary.
@@ -50,7 +52,6 @@ func (cs *CsiNfsService) updateKnownHosts() error {
 	}
 
 	// Read the known_hosts file
-	knownHostsPath := "/noderoot/root/.ssh/known_hosts"
 	knownHosts, err := os.ReadFile(knownHostsPath)
 	if err != nil {
 		return fmt.Errorf("failed to read known_hosts: %v", err)

--- a/nfs/init_nfs_server.go
+++ b/nfs/init_nfs_server.go
@@ -17,14 +17,69 @@ limitations under the License.
 package nfs
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
+func (cs *CsiNfsService) updateKnownHosts() error {
+	// Run ssh-keyscan
+	cmd, err := cs.executor.ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa", "localhost")
+	if err != nil {
+		return fmt.Errorf("failed to run ssh-keyscan: %v", err)
+	}
+	// Read the output of ssh-keyscan
+	newKey := string(cmd)
+
+	// Read the known_hosts file
+	knownHostsPath := "/noderoot/root/.ssh/known_hosts"
+	knownHosts, err := os.ReadFile(knownHostsPath)
+	if err != nil {
+		return fmt.Errorf("failed to read known_hosts: %v", err)
+	}
+
+	// Check if the key already exists
+	scanner := bufio.NewScanner(bytes.NewReader(knownHosts))
+	var updatedHosts bytes.Buffer
+	keyExists := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "localhost") {
+			updatedHosts.WriteString(newKey)
+			keyExists = true
+		} else if !strings.HasPrefix(line, "#") {
+			updatedHosts.WriteString(line + "\n")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan known_hosts: %v", err)
+	}
+
+	// Append the new key if it doesn't exist
+	log.Infof("keyExists: %t", keyExists)
+	if !keyExists {
+		updatedHosts.WriteString(newKey)
+	}
+
+	// Write the updated known_hosts file
+	if err := os.WriteFile(knownHostsPath, updatedHosts.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("failed to write known_hosts: %v", err)
+	}
+
+	return nil
+}
+
 // init_nfs_server uses systemctl to initialize an nfs server if necessary
 func (cs *CsiNfsService) initializeNfsServer() error {
 	log.Infof("checking status of nfs-server")
+	err := cs.updateKnownHosts()
+	if err != nil {
+		log.Warnf("Could not update known hosts, continuing.... error : %v", err)
+	}
 	// Check to see if nfs-server is active (exited ok)
 	// Note: systemctl doesn't work when invoked from a container unless you ssh localhost before executing it.
 	// You will get the message "Failed to connect to bus: No data available" because systemctl must think it's on the local host.
@@ -41,21 +96,24 @@ func (cs *CsiNfsService) initializeNfsServer() error {
 
 	// Reinitialize the NFS server if necessary
 	if !restartNfsServer {
+		log.Infof("nfs-server and nfs-mountd are active")
 		return nil
 	}
 
+	log.Infof("nfs-server and nfs-mountd are not active, attempting to configure them")
 	// First copy the nfs.conf file to /noderoot/etc/nfs.conf. This is a 2-step process.
-	log.Infof("Configuring /etc/nfs.conf")
-	out, err = cs.executor.ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf")
-	if err != nil {
-		log.Errorf("Couldn't copy /nfs.conf to /noderoot/tmp/nfs.conf: %s", string(out))
-		return err
-	}
-	out, err = cs.executor.ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf")
-	if err != nil {
-		log.Errorf("Couldn't copy /tmp/nfs.conf to /etc/nfs.conf: %s", string(out))
-		return err
-	}
+
+	// log.Infof("Configuring /etc/nfs.conf")
+	// out, err = cs.executor.ExecuteCommand("cp", "/etc/nfs.conf", "/noderoot/tmp/nfs.conf")
+	// if err != nil {
+	// 	log.Errorf("Couldn't copy /nfs.conf to /noderoot/tmp/nfs.conf: %s", string(out))
+	// 	return err
+	// }
+	// out, err = cs.executor.ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf")
+	// if err != nil {
+	// 	log.Errorf("Couldn't copy /tmp/nfs.conf to /etc/nfs.conf: %s", string(out))
+	// 	return err
+	// }
 
 	// Now enable the nfs-server
 	out, err = cs.executor.ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server")
@@ -83,5 +141,7 @@ func (cs *CsiNfsService) initializeNfsServer() error {
 		log.Infof("nfs-mountd not active: %s", string(out))
 		return err
 	}
+
+	log.Infof("nfs-server and nfs-mountd are now active")
 	return nil
 }

--- a/nfs/init_nfs_server.go
+++ b/nfs/init_nfs_server.go
@@ -93,7 +93,7 @@ func (cs *CsiNfsService) updateKnownHosts() error {
 	}
 
 	// Write the updated known_hosts file
-	if err := os.WriteFile(knownHostsPath, updatedHosts.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(knownHostsPath, updatedHosts.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to write known_hosts: %v", err)
 	}
 

--- a/nfs/init_nfs_server.go
+++ b/nfs/init_nfs_server.go
@@ -54,7 +54,17 @@ func (cs *CsiNfsService) updateKnownHosts() error {
 	// Read the known_hosts file
 	knownHosts, err := os.ReadFile(knownHostsPath)
 	if err != nil {
-		return fmt.Errorf("failed to read known_hosts: %v", err)
+		if os.IsNotExist(err) {
+			// Create an empty known_hosts file if it doesn't exist
+			_, err = os.Create(knownHostsPath)
+			if err != nil {
+				return fmt.Errorf("failed to create known_hosts file: %v", err)
+			}
+
+			knownHosts, _ = os.ReadFile(knownHostsPath)
+		} else {
+			return fmt.Errorf("failed to read known_hosts file: %v", err)
+		}
 	}
 
 	// Check if the keys already exist and update them if necessary

--- a/nfs/init_nfs_server_test.go
+++ b/nfs/init_nfs_server_test.go
@@ -37,10 +37,9 @@ func TestInitializeNfsServer(t *testing.T) {
 			name: "Valid NFS server - all commands successful",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "start", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte("Active: active"), nil)
@@ -56,6 +55,7 @@ func TestInitializeNfsServer(t *testing.T) {
 			name: "Server is active, no need to initialize",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte("Active: active"), nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
 
@@ -66,72 +66,12 @@ func TestInitializeNfsServer(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "Error copying nfs.conf file",
-			nfsServer: func() *CsiNfsService {
-				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, errors.New("error copying nfs.conf"))
-
-				return &CsiNfsService{
-					executor: mockExecutor,
-				}
-			}(),
-			expectedErr: errors.New("error copying nfs.conf"),
-		},
-		{
-			name: "Error with chroot copying nfs.conf file",
-			nfsServer: func() *CsiNfsService {
-				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, errors.New("error copying nfs.conf"))
-
-				return &CsiNfsService{
-					executor: mockExecutor,
-				}
-			}(),
-			expectedErr: errors.New("error copying nfs.conf"),
-		},
-		{
-			name: "Error with chroot copying nfs.conf file",
-			nfsServer: func() *CsiNfsService {
-				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, errors.New("error copying nfs.conf"))
-
-				return &CsiNfsService{
-					executor: mockExecutor,
-				}
-			}(),
-			expectedErr: errors.New("error copying nfs.conf"),
-		},
-		{
-			name: "Error with chroot copying nfs.conf file",
-			nfsServer: func() *CsiNfsService {
-				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, errors.New("error copying nfs.conf"))
-
-				return &CsiNfsService{
-					executor: mockExecutor,
-				}
-			}(),
-			expectedErr: errors.New("error copying nfs.conf"),
-		},
-		{
 			name: "Error with chroot ssh enable nfs-server service",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").Times(1).Return([]byte{}, errors.New("error chroot ssh enable"))
 				return &CsiNfsService{
 					executor: mockExecutor,
@@ -143,10 +83,9 @@ func TestInitializeNfsServer(t *testing.T) {
 			name: "Error with chroot ssh start nfs-server service",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "start", "nfs-server").Times(1).Return([]byte{}, errors.New("error chroot ssh start"))
 
@@ -160,10 +99,9 @@ func TestInitializeNfsServer(t *testing.T) {
 			name: "Error with chroot ssh status nfs-server service",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "start", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, errors.New("error chroot ssh status"))
@@ -178,10 +116,9 @@ func TestInitializeNfsServer(t *testing.T) {
 			name: "Error with chroot ssh status nfs-mountd service",
 			nfsServer: func() *CsiNfsService {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
+				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh-keyscan", "-t", "rsa,ecdsa,ed25519", "localhost").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-mountd").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("cp", "/nfs.conf", "/noderoot/tmp/nfs.conf").Times(1).Return([]byte{}, nil)
-				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "cp", "/tmp/nfs.conf", "/etc/nfs.conf").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "enable", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "start", "nfs-server").Times(1).Return([]byte{}, nil)
 				mockExecutor.EXPECT().ExecuteCommand("chroot", "/noderoot", "ssh", "localhost", "systemctl", "status", "nfs-server").Times(1).Return([]byte("Active: active"), nil)
@@ -197,7 +134,18 @@ func TestInitializeNfsServer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.nfsServer.initializeNfsServer()
+			knownHostsFile := `# localhost:22 SSH-2.0-OpenSSH_8.4
+			localhost ssh-rsa OLD_KEY
+			localhost ecdsa-sha2-nistp256 OLD_ECDSA_KEY
+			localhost ssh-ed25519 OLD_ED25519_KEY
+			`
+			var err error
+			knownHostsPath, err = setupKnownHosts(strings.ReplaceAll(knownHostsFile, "\t", ""))
+			if err != nil {
+				t.Fatalf("failed to set up known_hosts file: %v", err)
+			}
+			defer os.Remove(knownHostsPath)
+			err = test.nfsServer.initializeNfsServer()
 			assert.Equal(t, test.expectedErr, err)
 		})
 	}

--- a/nfs/nfs_service.go
+++ b/nfs/nfs_service.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	serverPort    = "2050"
+	serverPort    = opSys.Getenv(EnvNFSClientPort)
 	serverPortMux = &sync.Mutex{}
 )
 
@@ -93,10 +93,8 @@ func startNfsServiceServer(ipAddress, port string, listenFunc ListenFunc, serveF
 }
 
 func getNfsClient(ipaddress, port string) (proto.NfsClient, error) {
-	// TODO: add support for ipv6, add support for closing the client
+	// TODO check if this is still applicable: add support for ipv6, add support for closing the client
 	client, err := grpc.NewClient(ipaddress+":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	// below line is AI generated with deprecations
-	// conn, err := grpc.Dial(ipaddress+":"+port, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		log.Errorf("Could not connect to nfsService %s:%s", ipaddress, port)
 		return nil, err

--- a/nfs/nfs_service.go
+++ b/nfs/nfs_service.go
@@ -53,21 +53,8 @@ const (
 )
 
 var (
-	serverPort    = opSys.Getenv(EnvNFSClientPort)
 	serverPortMux = &sync.Mutex{}
 )
-
-func setServerPort(port string) {
-	serverPortMux.Lock()
-	defer serverPortMux.Unlock()
-	serverPort = port
-}
-
-func getServerPort() string {
-	serverPortMux.Lock()
-	defer serverPortMux.Unlock()
-	return serverPort
-}
 
 // Starts an NFS server on the specified string port
 func startNfsServiceServer(ipAddress, port string, listenFunc ListenFunc, serveFunc ServeFunc) error {

--- a/nfs/nfs_service.go
+++ b/nfs/nfs_service.go
@@ -52,9 +52,7 @@ const (
 	NfsFileModeString = "02777"
 )
 
-var (
-	serverPortMux = &sync.Mutex{}
-)
+var serverPortMux = &sync.Mutex{}
 
 // Starts an NFS server on the specified string port
 func startNfsServiceServer(ipAddress, port string, listenFunc ListenFunc, serveFunc ServeFunc) error {

--- a/nfs/nfs_service.go
+++ b/nfs/nfs_service.go
@@ -52,8 +52,6 @@ const (
 	NfsFileModeString = "02777"
 )
 
-var serverPortMux = &sync.Mutex{}
-
 // Starts an NFS server on the specified string port
 func startNfsServiceServer(ipAddress, port string, listenFunc ListenFunc, serveFunc ServeFunc) error {
 	log.Infof("csinfs: Calling Listen on %s", ipAddress+":"+port)

--- a/nfs/nfs_service_test.go
+++ b/nfs/nfs_service_test.go
@@ -424,7 +424,7 @@ func TestNFSPing(t *testing.T) {
 			}(),
 			executor: func() *mocks.MockExecutor {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]byte{}, nil)
+				mockExecutor.EXPECT().ExecuteCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]byte{}, nil)
 				return mockExecutor
 			}(),
 			osMock: func() *mocks.MockOSInterface {
@@ -482,7 +482,7 @@ func TestNFSPing(t *testing.T) {
 			}(),
 			executor: func() *mocks.MockExecutor {
 				mockExecutor := mocks.NewMockExecutor(gomock.NewController(t))
-				mockExecutor.EXPECT().ExecuteCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]byte{}, nil)
+				mockExecutor.EXPECT().ExecuteCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]byte{}, nil)
 				return mockExecutor
 			}(),
 			osMock: func() *mocks.MockOSInterface {

--- a/nfs/nodemonitor.go
+++ b/nfs/nodemonitor.go
@@ -87,7 +87,7 @@ func (s *CsiNfsService) GetNodeStatus(address string) *NodeStatus {
 func (s *CsiNfsService) ping(pingRequest *proto.PingRequest) (*proto.PingResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), Pinger.timeout)
 	defer cancel()
-	nodeClient, err := getNfsClient(pingRequest.NodeIpAddress, getServerPort())
+	nodeClient, err := getNfsClient(pingRequest.NodeIpAddress, s.nfsServerPort)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (s *CsiNfsService) ping(pingRequest *proto.PingRequest) (*proto.PingRespons
 func (s *CsiNfsService) getExports(nodeIP string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), GetExportsTimeout)
 	defer cancel()
-	nodeClient, err := getNfsClient(nodeIP, getServerPort())
+	nodeClient, err := getNfsClient(nodeIP, s.nfsServerPort)
 	if err != nil {
 		return make([]string, 0), err
 	}

--- a/nfs/nodemonitor.go
+++ b/nfs/nodemonitor.go
@@ -87,7 +87,7 @@ func (s *CsiNfsService) GetNodeStatus(address string) *NodeStatus {
 func (s *CsiNfsService) ping(pingRequest *proto.PingRequest) (*proto.PingResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), Pinger.timeout)
 	defer cancel()
-	nodeClient, err := getNfsClient(pingRequest.NodeIpAddress, s.nfsServerPort)
+	nodeClient, err := getNfsClient(pingRequest.NodeIpAddress, s.nfsClientServicePort)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (s *CsiNfsService) ping(pingRequest *proto.PingRequest) (*proto.PingRespons
 func (s *CsiNfsService) getExports(nodeIP string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), GetExportsTimeout)
 	defer cancel()
-	nodeClient, err := getNfsClient(nodeIP, s.nfsServerPort)
+	nodeClient, err := getNfsClient(nodeIP, s.nfsClientServicePort)
 	if err != nil {
 		return make([]string, 0), err
 	}

--- a/nfs/nodemonitor_test.go
+++ b/nfs/nodemonitor_test.go
@@ -67,7 +67,7 @@ func TestGetExports(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := CsiNfsService{
-				nfsServerPort: port,
+				nfsClientServicePort: port,
 			}
 
 			server := mocks.NewMockNfsServer(gomock.NewController(t))
@@ -121,7 +121,7 @@ func TestPing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := CsiNfsService{nfsServerPort: port}
+			s := CsiNfsService{nfsClientServicePort: port}
 
 			server := mocks.NewMockNfsServer(gomock.NewController(t))
 			if tt.wantErr {
@@ -212,7 +212,7 @@ func TestGetNodeExportCounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := CsiNfsService{nfsServerPort: port}
+			s := CsiNfsService{nfsClientServicePort: port}
 
 			tt.createServer(t)
 
@@ -314,7 +314,7 @@ func TestPinger(t *testing.T) {
 				k8sclient: &k8s.Client{
 					Clientset: clientset,
 				},
-				nfsServerPort: port,
+				nfsClientServicePort: port,
 			}
 
 			tt.createServer(t)
@@ -393,7 +393,7 @@ func TestStartNodeMonitor(t *testing.T) {
 		{
 			name: "Success: ControlPlaneNode",
 			nfsServer: func() *CsiNfsService {
-				s := &CsiNfsService{nfsServerPort: port}
+				s := &CsiNfsService{nfsClientServicePort: port}
 				return s
 			}(),
 			node: &v1.Node{
@@ -412,7 +412,7 @@ func TestStartNodeMonitor(t *testing.T) {
 		{
 			name: "Success: NonControlPlaneNode",
 			nfsServer: func() *CsiNfsService {
-				s := &CsiNfsService{nfsServerPort: port}
+				s := &CsiNfsService{nfsClientServicePort: port}
 				return s
 			}(),
 			node: &v1.Node{

--- a/nfs/noderecovery_test.go
+++ b/nfs/noderecovery_test.go
@@ -181,7 +181,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				clientset.CoreV1().PersistentVolumes().Create(context.Background(), &v1.PersistentVolume{
@@ -213,7 +213,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				// Create Persistent Volume
@@ -263,7 +263,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				// Create Persistent Volume
@@ -312,7 +312,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				// Create Persistent Volume
@@ -378,7 +378,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				// Create Persistent Volume
@@ -444,7 +444,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				// Create Persistent Volume
@@ -562,7 +562,7 @@ func TestUpdateEndpointSlice(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				clientset.DiscoveryV1().EndpointSlices("").Create(context.Background(), slice, metav1.CreateOptions{})
@@ -581,7 +581,7 @@ func TestUpdateEndpointSlice(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
-					nfsServerPort: port,
+					nfsClientServicePort: port,
 				}
 
 				return s

--- a/nfs/noderecovery_test.go
+++ b/nfs/noderecovery_test.go
@@ -18,7 +18,10 @@ package nfs
 
 import (
 	"context"
+	"crypto/rand"
+	"math/big"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -37,6 +40,10 @@ import (
 )
 
 func TestNodeRecovery(t *testing.T) {
+	port := func() string {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(9000))
+		return strconv.Itoa(int(nBig.Int64() + 1000))
+	}()
 	nodeIP := "127.0.0.1"
 	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
@@ -95,7 +102,7 @@ func TestNodeRecovery(t *testing.T) {
 				clientset.DiscoveryV1().EndpointSlices("").Create(context.Background(), slice, metav1.CreateOptions{})
 
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
-				createMockServer(t, "127.0.0.2", server)
+				createMockServer(t, "127.0.0.2", port, server)
 				// Give it time for the server to setup
 				time.Sleep(50 * time.Millisecond)
 
@@ -116,6 +123,11 @@ func TestNodeRecovery(t *testing.T) {
 }
 
 func TestReassignVolume(t *testing.T) {
+	port := func() string {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(9000))
+		return strconv.Itoa(int(nBig.Int64() + 1000))
+	}()
+
 	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mySlice",
@@ -169,6 +181,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				clientset.CoreV1().PersistentVolumes().Create(context.Background(), &v1.PersistentVolume{
@@ -200,6 +213,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				// Create Persistent Volume
@@ -249,6 +263,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				// Create Persistent Volume
@@ -297,6 +312,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				// Create Persistent Volume
@@ -362,6 +378,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				// Create Persistent Volume
@@ -427,6 +444,7 @@ func TestReassignVolume(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				// Create Persistent Volume
@@ -482,7 +500,7 @@ func TestReassignVolume(t *testing.T) {
 				server := mocks.NewMockNfsServer(gomock.NewController(t))
 				server.EXPECT().ExportNfsVolume(gomock.Any(), gomock.Any()).Times(1).Return(&proto.ExportNfsVolumeResponse{VolumeId: uuid.New().String()}, nil)
 
-				createMockServer(t, "127.0.0.1", server)
+				createMockServer(t, "127.0.0.1", port, server)
 				// Give it time for the server to setup
 				time.Sleep(50 * time.Millisecond)
 
@@ -506,6 +524,10 @@ func TestReassignVolume(t *testing.T) {
 }
 
 func TestUpdateEndpointSlice(t *testing.T) {
+	port := func() string {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(9000))
+		return strconv.Itoa(int(nBig.Int64() + 1000))
+	}()
 	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mySlice",
@@ -540,6 +562,7 @@ func TestUpdateEndpointSlice(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				clientset.DiscoveryV1().EndpointSlices("").Create(context.Background(), slice, metav1.CreateOptions{})
@@ -558,6 +581,7 @@ func TestUpdateEndpointSlice(t *testing.T) {
 					k8sclient: &k8s.Client{
 						Clientset: clientset,
 					},
+					nfsServerPort: port,
 				}
 
 				return s


### PR DESCRIPTION
# Description
1. Added logic to support dynamic port configuration for nfs-server and nfs-client. 
2. Updated init NFS server logic to setup known_hosts for localhost and invoke necessary calls. 

Note:
NFS server port configuration is dependent on editing the /etc/nfs.conf file. This is not being done dynamically today from HBNFS code. However, if the default NFS port were modified outside, then that port can be specified for csm-hbnfs to pick up. 
Also, ssh localhost only works on kubernetes at the moment, need a solution for OCP, which will be taken up in a different PR. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
[https://github.com/dell/csm/issues/1742]

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
Unit test results:
![image](https://github.com/user-attachments/assets/7646fbe1-0b33-4393-af44-c256d425ce64)


Manually tested NFS volume provisioning with ports made configurable
