### PR TITLE
Fixing nil pointer deref in CreateVolume

### DIFF
--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -63,11 +63,18 @@ func (cs *CsiNfsService) CreateVolume(ctx context.Context, req *csi.CreateVolume
 		},
 	}
 	subreq.VolumeCapabilities = []*csi.VolumeCapability{blockVolumeCapability}
-	log.Infof("Calling vcsi.CreateVolume parameters %+v capabilities %v", subreq.Parameters, subreq.VolumeCapabilities)
+
+	log.Debugf("HBNFS CreateVolume: calling vcsi.CreateVolume; parameters: %+v; capabilities: %v", subreq.Parameters, subreq.VolumeCapabilities)
 	resp, err := cs.vcsi.CreateVolume(ctx, subreq)
+	if err != nil {
+		log.Errorf("HBNFS CreateVolume: failed to create volume; err: %s", err.Error())
+		return resp, err
+	}
+
 	resp.Volume.VolumeId = ArrayToNFSVolumeID(resp.Volume.VolumeId)
-	log.Infof("Returning CreateVolume error %s resp %+v", err, resp)
-	return resp, err
+	log.Infof("HBNFS CreateVolume: response %+v", resp)
+
+	return resp, nil
 }
 
 func (cs *CsiNfsService) DeleteVolume(_ context.Context, _ *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {


### PR DESCRIPTION
# Description
The `CreateVolume` response from the driver can return a nil `csi.CreateVolumeResponse` pointer and an error, meaning we would, at times, attempt to modify the nil response to add the `nfs-` prefix to the VolumeId struct member, triggering a nil pointer dereference, and sending the csi-powerstore controller pods into CrashLoopBackoff.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] ~Have you done corresponding changes to the documentation~
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Attempted to provision storage with HBNFS that would knowingly cause the csi-powerstore `CreateVolume` response to return an error. Checked the logs to confirm the error was logged and returned by csm-hbnfs `CreateVolume` function. Confirmed the driver pods no longer entered CLBO as they did previously.
