### PR TITLE
Remove panic and return error in BeforeServe when missing parameter

### DIFF
--- a/nfs/csinfs.go
+++ b/nfs/csinfs.go
@@ -262,9 +262,11 @@ func (s *CsiNfsService) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin,
 	if s.nodeName == "" {
 		s.nodeName = opSys.Getenv(EnvNodeName)
 	}
+
 	if s.nodeName == "" {
-		panic("X_CSI_NODE_NAME or NODE_NAME environment variable not set")
+		return fmt.Errorf("X_CSI_NODE_NAME or NODE_NAME environment variable not set")
 	}
+
 	log.Infof("NFS Driver Mode: %s Node Name %s", s.mode, s.nodeName)
 
 	s.nfsServerPort = os.Getenv(EnvNFSServerPort)


### PR DESCRIPTION
# Description
Return the error instead of performing a panic in the `BeforeServe`. This was causing misleading errors and CrashLoopBackOff for the controller Pod when the `X_CSI_NODE_NAME` is not present.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Ensure that unit tests pass as expected.
- [x] Run changes on a real cluster and make sure that the driver still works if the parameter is missing.
