### PR TITLE
Cleaning up NFS server install script

### DIFF
--- a/rhel_nfs4.sh
+++ b/rhel_nfs4.sh
@@ -17,14 +17,14 @@ fi
 
 
 echo "copying nfs.conf"
-copy cp rhel_nfs.conf /etc/nfs.conf
+echo cp rhel_nfs.conf /etc/nfs.conf
 cp rhel_nfs.conf /etc/nfs.conf
 
 echo "disabling v3 services"
 echo systemctl mask --now rpc-statd.service rpcbind.service rpcbind.socket
 systemctl mask --now rpc-statd.service rpcbind.service rpcbind.socket
 
-"configuring nfs-mount.service.d"
+echo "configuring nfs-mount.service.d"
 echo mkdir /etc/systemd/nfs-mount.service.d
 mkdir /etc/systemd/nfs-mount.service.d
 cat >/etc/systemd/nfs-mount.service.d/v4only.conf <<END
@@ -40,7 +40,7 @@ systemctl restart nfs-mountd
 
 echo "should see nfsd processes: "
 ps axl | grep nfsd
-echo "... done
+echo "... done"
 
 mkdir /nfs
 mkdir /nfs/exports
@@ -55,13 +55,12 @@ echo "setting test export"
 echo mkdir /nfs/exports
 mkdir /nfs/exports
 echo chgrp users /nfs/exports
-echo chgrp users /nfs/exports
 chgrp users /nfs/exports
 echo chmod 02770 /nfs/exports
 chmod 02770 /nfs/exports
 echo mkdir /nfs/exports/hello
 mkdir /nfs/exports/hello
-echochgrp users /nfs/exports/hello
+echo chgrp users /nfs/exports/hello
 chgrp users /nfs/exports/hello
 echo chmod 02777 /nfs/exports/hello
 chmod 02777 /nfs/exports/hello
@@ -70,6 +69,6 @@ echo "hello world" > /nfs/exports/hello/world
 echo "updating /etc/exports"
 echo "/nfs/exports/hello/  $ip/24(rw)" >> /etc/exports
 cat /etc/exports
-systemctl restart nfs.mountd
+systemctl restart nfs-mountd
 
-echo "check that you can mount /nfs/exports/hello with\nmkdir hello && mount -t nfs4 $ip:/exports/hello /hello"
+echo -e "check that you can mount /nfs/exports/hello with\n\tmkdir ./hello && mount -t nfs4 $ip:/nfs/exports/hello ./hello"


### PR DESCRIPTION
# Description
Cleaning up the NFS server install script
- fixing a few typos, missing quotations, and incorrect dir paths.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Installed and configured the NFS server on cluster nodes, and provisioned storage with `cert-csi test volumeio` test

```bash
$ cert-csi test volumeio --chainNumber 1 --chainLength 1 --sc powerstore-hbnfs
[2025-04-17 16:18:10]  INFO Running 1 iteration(s)
[2025-04-17 16:18:10]  INFO     *** ITERATION NUMBER 1 ***
[2025-04-17 16:18:10]  INFO Starting VolumeIoSuite with powerstore-hbnfs storage class
...
[2025-04-17 16:18:58]  INFO SUCCESS: VolumeIoSuite in 47.849998779s
[2025-04-17 16:18:58]  INFO Avg time of a run:   35.77s
[2025-04-17 16:18:58]  INFO Avg time of a del:   12.02s
[2025-04-17 16:18:58]  INFO Avg time of all:     47.80s
[2025-04-17 16:18:58]  INFO During this run 100.0% of suites succeeded
```