### PR TITLE
Update control plane check

### DIFF
--- a/nfs/csinfs_test.go
+++ b/nfs/csinfs_test.go
@@ -510,11 +510,9 @@ func TestCsiNfsService_startNodeMonitors(t *testing.T) {
 				k8sclient: func() *k8s.Client {
 					clientSet := fake.NewClientset()
 					_, err := clientSet.CoreV1().Nodes().Create(context.Background(), &v1.Node{
-						Spec: v1.NodeSpec{
-							Taints: []v1.Taint{
-								{
-									Key: "node-role.kubernetes.io/control-plane",
-								},
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"node-role.kubernetes.io/control-plane": "",
 							},
 						},
 					}, metav1.CreateOptions{})

--- a/nfs/nodemonitor.go
+++ b/nfs/nodemonitor.go
@@ -207,8 +207,8 @@ func (s *CsiNfsService) getNodeExportCounts(_ context.Context) map[string]int {
 }
 
 func isControlPlaneNode(node *v1.Node) bool {
-	for _, taint := range node.Spec.Taints {
-		if taint.Key == "node-role.kubernetes.io/control-plane" {
+	for key := range node.Labels {
+		if key == "node-role.kubernetes.io/control-plane" {
 			return true
 		}
 	}

--- a/nfs/nodemonitor_test.go
+++ b/nfs/nodemonitor_test.go
@@ -337,35 +337,31 @@ func TestIsControlPlaneNode(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "node without taints",
+			name: "node without labels",
 			node: &v1.Node{
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
 				},
 			},
 			want: false,
 		},
 		{
-			name: "node with taint but not control-plane taint",
+			name: "node with labels but not control-plane label",
 			node: &v1.Node{
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{
-							Key: "node-role.kubernetes.io/other-taint",
-						},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node-role.kubernetes.io/other-label": "myLabel",
 					},
 				},
 			},
 			want: false,
 		},
 		{
-			name: "node with control-plane taint",
+			name: "node with control-plane label",
 			node: &v1.Node{
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{
-							Key: "node-role.kubernetes.io/control-plane",
-						},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node-role.kubernetes.io/control-plane": "",
 					},
 				},
 			},

--- a/nfs/nodemonitor_test.go
+++ b/nfs/nodemonitor_test.go
@@ -396,12 +396,8 @@ func TestStartNodeMonitor(t *testing.T) {
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "control-plane-node",
-				},
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{
-							Key: "node-role.kubernetes.io/control-plane",
-						},
+					Labels: map[string]string{
+						"node-role.kubernetes.io/control-plane": "",
 					},
 				},
 			},
@@ -415,12 +411,8 @@ func TestStartNodeMonitor(t *testing.T) {
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "non-control-plane-node",
-				},
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{
-							Key: "NonControlPlaneNodeTaint",
-						},
+					Labels: map[string]string{
+						"NonControlPlaneNodeLabel": "",
 					},
 				},
 			},


### PR DESCRIPTION
# Description
Update the control plane check from taints to labels. In both k8s and OCP, the node roles is determined by the labels. In OCP, the taints does not contain the appropriate `control-plane` which causes the controller pods to ping ALL nodes which is not the desire approach.

**Issue on OCP:**
We start a pinger for all master nodes:
```
{"level":"info","msg":"pinger: starting on node hb-master-<masterIP>.hb.hop.lab.emc.com","time":"2025-04-25T18:12:08.829318788Z"}
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- [x] Manually deployed on a k8s cluster and ensure that we are detecting the correct nodes based on their roles.
