### PR TITLE
Rename storage class parameter from csi-nfs to shared-nfs

### DIFF
--- a/nfs/controller.go
+++ b/nfs/controller.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	CsiNfsParameter  = "csi-nfs"
+	CsiNfsParameter  = "shared-nfs"
 	CsiNfsPrefix     = "nfs"
 	CsiNfsPrefixDash = "nfs-"
 	ServiceName      = "ServiceName"
@@ -211,7 +211,7 @@ func (cs *CsiNfsService) makeNfsService(ctx context.Context, namespace, name str
 	// Export the volume to this node by calling back into the host driver
 	subreq := req
 	subreq.VolumeId = ToArrayVolumeID(req.VolumeId)
-	subreq.VolumeContext["csi-nfs"] = ""
+	subreq.VolumeContext["shared-nfs"] = ""
 	log.Infof("Calling host driver to publish volume %s to node %s", subreq.VolumeId, subreq.NodeId)
 	// TODO: consider do we ever need a different access mode
 	blockVolumeCapability := &csi.VolumeCapability{

--- a/nfs/controller_test.go
+++ b/nfs/controller_test.go
@@ -288,7 +288,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				mockService := mocks.NewMockService(gomock.NewController(t))
 				mockService.EXPECT().ControllerPublishVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						"csi-nfs": "test-node",
+						"shared-nfs": "test-node",
 					},
 				}, nil)
 				fakeK8sClient := fake.NewSimpleClientset()
@@ -442,7 +442,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				mockService := mocks.NewMockService(gomock.NewController(t))
 				mockService.EXPECT().ControllerPublishVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						"csi-nfs": "test-node",
+						"shared-nfs": "test-node",
 					},
 				}, nil)
 				fakeK8sClient := fake.NewSimpleClientset()
@@ -522,7 +522,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				mockService := mocks.NewMockService(gomock.NewController(t))
 				mockService.EXPECT().ControllerPublishVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						"csi-nfs": "test-node",
+						"shared-nfs": "test-node",
 					},
 				}, nil)
 				fakeK8sClient := fake.NewSimpleClientset()
@@ -582,7 +582,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				mockService := mocks.NewMockService(gomock.NewController(t))
 				mockService.EXPECT().ControllerPublishVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						"csi-nfs": "test-node",
+						"shared-nfs": "test-node",
 					},
 				}, nil)
 				fakeK8sClient := fake.NewSimpleClientset()
@@ -676,7 +676,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				mockService := mocks.NewMockService(gomock.NewController(t))
 				mockService.EXPECT().ControllerPublishVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						"csi-nfs": "test-node",
+						"shared-nfs": "test-node",
 					},
 				}, nil)
 				fakeK8sClient := fake.NewSimpleClientset()

--- a/nfs/csinfs.go
+++ b/nfs/csinfs.go
@@ -121,7 +121,7 @@ func (o *OSImpl) Chmod(fileName string, mode os.FileMode) error {
 }
 
 func IsNFSStorageClass(parameters map[string]string) bool {
-	return parameters["csi-nfs"] == "RWX"
+	return parameters["shared-nfs"] == "RWX"
 }
 
 func hasNFSPrefix(id string) bool {
@@ -223,7 +223,7 @@ func (s *CsiNfsService) validateGlobalVariables() error {
 	}
 	if s.mode == "node" {
 		if NodeRoot == "" {
-			return fmt.Errorf("csi-nfs NodeRoot variable must be set; used for chroot into node; validated with /noderoot/etc/exports")
+			return fmt.Errorf("shared-nfs NodeRoot variable must be set; used for chroot into node; validated with /noderoot/etc/exports")
 		}
 		_, err := opSys.Stat(NodeRoot + "/etc/exports")
 		if err != nil {

--- a/nfs/csinfs_test.go
+++ b/nfs/csinfs_test.go
@@ -53,7 +53,7 @@ func TestIsNFSStorageClass(t *testing.T) {
 			name: "is nfs storage class",
 			args: args{
 				parameters: map[string]string{
-					"csi-nfs": "RWX",
+					"shared-nfs": "RWX",
 				},
 			},
 			want: true,
@@ -62,13 +62,13 @@ func TestIsNFSStorageClass(t *testing.T) {
 			name: "is not nfs storage class",
 			args: args{
 				parameters: map[string]string{
-					"csi-nfs": "RWO",
+					"shared-nfs": "RWO",
 				},
 			},
 			want: false,
 		},
 		{
-			name: "parameters missing key 'csi-nfs' key",
+			name: "parameters missing key 'shared-nfs' key",
 			args: args{
 				parameters: map[string]string{
 					"missing-key": "RWX",
@@ -374,7 +374,7 @@ func TestCsiNfsService_validateGlobalVariables(t *testing.T) {
 				NodeRoot = ""
 			},
 			wantErr:    true,
-			wantErrMsg: "csi-nfs NodeRoot variable must be set; used for chroot into node; validated with /noderoot/etc/exports",
+			wantErrMsg: "shared-nfs NodeRoot variable must be set; used for chroot into node; validated with /noderoot/etc/exports",
 		},
 		{
 			name: "mode is controller and driver namespace is unset",

--- a/nfs/k8s/k8s.go
+++ b/nfs/k8s/k8s.go
@@ -45,18 +45,18 @@ var RestInClusterConfigFunc = func() (*rest.Config, error) {
 func Connect() (*Client, error) {
 	k8sclient := new(Client)
 	var err error
-	log.Info("csi-nfs: attempting k8sapi connection using InClusterConfig")
+	log.Info("shared-nfs: attempting k8sapi connection using InClusterConfig")
 	config, err := RestInClusterConfigFunc()
 	if err != nil {
 		return nil, err
 	}
 	cs, err := NewForConfigFunc(config)
 	if err != nil {
-		log.Error("csi-nfs: unable to connect to k8sapi: " + err.Error())
+		log.Error("shared-nfs: unable to connect to k8sapi: " + err.Error())
 		return nil, err
 	}
 	k8sclient.Clientset = cs
-	log.Info("csi-nfs: connected to k8sapi")
+	log.Info("shared-nfs: connected to k8sapi")
 	return k8sclient, nil
 }
 
@@ -102,33 +102,33 @@ func (kc *Client) GetNode(ctx context.Context, nodeName string) (*v1.Node, error
 
 // GetlEndpointSlices returns the endpointslices matching match labels.
 func (kc *Client) GetEndpointSlices(ctx context.Context, namespace, labelSelector string) ([]*discoveryv1.EndpointSlice, error) {
-	log.Infof("csi-nfs: retrieving all endpointslices")
+	log.Infof("shared-nfs: retrieving all endpointslices")
 	sliceList, err := kc.Clientset.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
-		log.Errorf("csi-nfs: error retrieving endpointslices: %s: %s", labelSelector, err.Error())
-		return nil, fmt.Errorf("csi-nfs: error retrieving endpointslices: %s: %s", labelSelector, err.Error())
+		log.Errorf("shared-nfs: error retrieving endpointslices: %s: %s", labelSelector, err.Error())
+		return nil, fmt.Errorf("shared-nfs: error retrieving endpointslices: %s: %s", labelSelector, err.Error())
 	}
 	slices := make([]*discoveryv1.EndpointSlice, 0)
 	for _, slice := range sliceList.Items {
 		slices = append(slices, &slice)
 	}
-	log.Infof("csi-nfs: retrieved %d endpointslices", len(slices))
+	log.Infof("shared-nfs: retrieved %d endpointslices", len(slices))
 	return slices, err
 }
 
 // GetAllNodes retrieves all nodes in the Kubernetes cluster
 func (kc *Client) GetAllNodes(ctx context.Context) ([]*v1.Node, error) {
 	nodes := make([]*v1.Node, 0)
-	log.Info("csi-nfs: retrieving all nodes")
+	log.Info("shared-nfs: retrieving all nodes")
 	nodeList, err := kc.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		log.Error("csi-nfs: error retrieving nodes: " + err.Error())
+		log.Error("shared-nfs: error retrieving nodes: " + err.Error())
 		return nil, err
 	}
 	for _, node := range nodeList.Items {
 		nodes = append(nodes, &node)
 	}
-	log.Infof("csi-nfs: retrieved %d nodes", len(nodeList.Items))
+	log.Infof("shared-nfs: retrieved %d nodes", len(nodeList.Items))
 	return nodes, nil
 }
 


### PR DESCRIPTION
# Description
Rename storage class parameter from csi-nfs to shared-nfs.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- Built driver with these changes and verified new storage class parameter is used for SharedNFS.